### PR TITLE
fix bug: CLE sample-trajectories leaving the standard simplex

### DIFF
--- a/sponet/cnvm/approximations/chemical_langevin_equation.py
+++ b/sponet/cnvm/approximations/chemical_langevin_equation.py
@@ -93,7 +93,11 @@ def _numba_euler_maruyama(
     for i in range(num_time_steps):
         drift, diffusion = _drift_and_diffusion(x[i], r, r_tilde, num_agents)
         x[i + 1] = x[i] + drift * delta_t + diffusion @ wiener_increments[i]
+
+        # Wiener increments can lead to negative values that cause problems for square root
         x[i + 1] = np.clip(x[i + 1], 0, 1)
+        # Renormalize after clipping to contain trajectory in standard simplex
+        x[i + 1] /= np.sum(x[i + 1])
 
     return x
 


### PR DESCRIPTION
In the `_numba_euler_maruyama` function, the trajectories were clipped if one of the relative shares left the [0,1] interval. Due to this clipping, the relative shares did not sum up to 1 which lead to a deterioration of the CLE trajectory over time. This was especially an issue with small network sizes where the variance was high and trajectories ran often into the 0 or 1 boundaries.

The fix renormalizes the trajectory after the clipping. This contains the trajectory inside the standard simplex.