### PR TITLE
Make CNVMParameters a normal class (instead of dataclass)

### DIFF
--- a/sponet/cnvm/parameters.py
+++ b/sponet/cnvm/parameters.py
@@ -280,7 +280,7 @@ def convert_rate_to_cnvm(
     return r_imit, r_noise, prob_imit, prob_noise
 
 
-def convert_rate_from_cnvm(params: CNVMParameters) -> tuple[np.ndarray, np.ndarray]:
+def convert_rate_from_cnvm(params: CNVMParameters) -> tuple[NDArray, NDArray]:
     """
     Convert the rates used in the CNVM to r and r_tilde.
 


### PR DESCRIPTION
Same functionality, but it is more clear what types the fields of the class can have. This should fix some warnings/errors of LSPs.