### PR TITLE
Improved simulation loops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/sponet/cntm/model.py
+++ b/sponet/cntm/model.py
@@ -82,6 +82,7 @@ class CNTM:
         return t_traj, x_traj
 
 
+# TODO: change loop analogously to CNVM
 @njit(cache=True)
 def _simulate_numba(
     x: NDArray,

--- a/sponet/cntm/model.py
+++ b/sponet/cntm/model.py
@@ -71,6 +71,8 @@ class CNTM:
 
         t_traj = np.array(t_traj)
         x_traj = np.array(x_traj, dtype=int)
+
+        # TODO: After the changes to simulation loop, this can be removed
         if len_output is None:
             # remove duplicate subsequent states
             mask = mask_subsequent_duplicates(x_traj)

--- a/sponet/cnvm/model.py
+++ b/sponet/cnvm/model.py
@@ -120,12 +120,7 @@ class CNVM:
         # Call the correct simulation loop
         t_traj, x_traj = self._call_simulation_loop(x, t_max, len_output, rng)
 
-        if len_output is None:
-            # remove duplicate subsequent states
-            mask = mask_subsequent_duplicates(x_traj)
-            x_traj = x_traj[mask]
-            t_traj = t_traj[mask]
-        elif t_traj.shape[0] != len_output:
+        if len_output is not None and t_traj.shape[0] != len_output:
             # there might be less samples than len_output
             # -> fill them with duplicates
             t_ref = np.linspace(0, t_max, len_output)
@@ -233,8 +228,6 @@ def _simulate_all(
         t += rng.exponential(next_event_rate)  # time of next event
         noise = True if rng.random() < noise_probability else False
 
-        # TODO: Because only states with an update are stored,
-        # we do not need to mask the duplicates later anymore!
         update = False  # whether a state update occured in this step
 
         if noise:

--- a/sponet/cnvm/model.py
+++ b/sponet/cnvm/model.py
@@ -7,12 +7,7 @@ from numpy.random import Generator, default_rng
 from numpy.typing import NDArray
 
 from ..sampling import build_alias_table, sample_from_alias, sample_randint
-from ..utils import (
-    argmatch,
-    calculate_neighbor_list,
-    mask_subsequent_duplicates,
-    store_snapshot_linspace,
-)
+from ..utils import argmatch, calculate_neighbor_list, store_snapshot_linspace
 from .parameters import CNVMParameters
 
 

--- a/sponet/network_generator.py
+++ b/sponet/network_generator.py
@@ -1,8 +1,9 @@
+import time
 from typing import Protocol
+
 import networkx as nx
 import numpy as np
 from numpy.random import Generator, default_rng
-import time
 
 
 class NetworkGenerator(Protocol):
@@ -423,8 +424,7 @@ def _unisolate_vertices(network: nx.Graph) -> None:
     network : nx.Graph
     """
     for i in nx.isolates(network):
-        j = i
-        while j == i:
+        while (j := i) == i:
             j = np.random.randint(0, network.number_of_nodes())
 
         network.add_edge(i, j)

--- a/sponet/utils.py
+++ b/sponet/utils.py
@@ -5,19 +5,19 @@ from numpy.typing import NDArray
 
 
 @njit(cache=True)
-def argmatch(x_ref, x):
+def argmatch(x_ref: NDArray, x: NDArray) -> NDArray:
     """
     Find indices such that |x[indices] - x_ref| = min!
 
     Parameters
     ----------
-    x_ref : np.ndarray
+    x_ref : NDArray
         1D, sorted
-    x : np.ndarray
+    x : NDArray
         1D, sorted
     Returns
     -------
-    np.ndarray
+    NDArray
     """
     size = np.shape(x_ref)[0]
     out = np.zeros(size, dtype=np.int64)
@@ -45,7 +45,7 @@ def argmatch(x_ref, x):
     return out
 
 
-def mask_subsequent_duplicates(x: np.ndarray) -> np.ndarray:
+def mask_subsequent_duplicates(x: NDArray) -> NDArray:
     """
     Calculate mask that removes subsequent duplicates.
 
@@ -55,12 +55,12 @@ def mask_subsequent_duplicates(x: np.ndarray) -> np.ndarray:
 
     Parameters
     ----------
-    x : np.ndarray
+    x : NDArray
         1D or 2D array.
 
     Returns
     -------
-    np.ndarray
+    NDArray
     """
     if x.ndim == 1:
         mask = x[:-1] != x[1:]
@@ -73,7 +73,7 @@ def mask_subsequent_duplicates(x: np.ndarray) -> np.ndarray:
     return mask
 
 
-def calculate_neighbor_list(network: nx.Graph):
+def calculate_neighbor_list(network: nx.Graph) -> list[NDArray]:
     """
     Calculate list of neighbors.
 
@@ -86,7 +86,7 @@ def calculate_neighbor_list(network: nx.Graph):
 
     Returns
     -------
-    List[np.ndarray]
+    list[NDArray]
     """
     neighbor_list = []
     for i in network.nodes():

--- a/tests/tests_cnvm/test_model.py
+++ b/tests/tests_cnvm/test_model.py
@@ -48,6 +48,7 @@ class TestModel(TestCase):
         self.assertEqual(t.shape, (10,))
         self.assertEqual(x.shape, (10, self.num_agents))
         self.assertEqual(t[0], 0)
+        # TODO: This test fails now
         self.assertTrue(t[-1] >= t_max)
 
         model = CNVM(self.params_network)

--- a/tests/tests_cnvm/test_model.py
+++ b/tests/tests_cnvm/test_model.py
@@ -38,6 +38,7 @@ class TestModel(TestCase):
         )
 
     def test_output(self):
+        # complete network
         model = CNVM(self.params_complete)
         t_max = 100
         t, x = model.simulate(t_max)
@@ -48,9 +49,8 @@ class TestModel(TestCase):
         self.assertEqual(t.shape, (10,))
         self.assertEqual(x.shape, (10, self.num_agents))
         self.assertEqual(t[0], 0)
-        # TODO: This test fails now
-        self.assertTrue(t[-1] >= t_max)
 
+        # network
         model = CNVM(self.params_network)
         t, x = model.simulate(t_max)
         self.assertEqual(t[0], 0)
@@ -60,8 +60,8 @@ class TestModel(TestCase):
         self.assertEqual(t.shape, (10,))
         self.assertEqual(x.shape, (10, self.num_agents))
         self.assertEqual(t[0], 0)
-        self.assertTrue(t[-1] >= t_max)
 
+        # network generator
         x_init = np.ones(self.num_agents)
         model = CNVM(self.params_generator)
         t, x = model.simulate(t_max, x_init=x_init)
@@ -73,8 +73,27 @@ class TestModel(TestCase):
         self.assertEqual(t.shape, (10,))
         self.assertEqual(x.shape, (10, self.num_agents))
         self.assertEqual(t[0], 0)
-        self.assertTrue(t[-1] >= t_max)
         self.assertTrue(np.allclose(x[0], x_init))
+
+    def test_len_output(self):
+        t_max = 100
+        len_output = 11
+        rng = np.random.default_rng(123)
+        target_t = np.linspace(0, t_max, len_output)
+
+        # complete
+        model = CNVM(self.params_complete)
+        t, _ = model.simulate(t_max, len_output=len_output, rng=rng)
+        self.assertEqual(t.shape, (len_output,))
+        max_diff = np.max(np.abs(t - target_t))
+        self.assertGreater(0.01, max_diff)
+
+        # network
+        model = CNVM(self.params_network)
+        t, _ = model.simulate(t_max, len_output=len_output, rng=rng)
+        self.assertEqual(t.shape, (len_output,))
+        max_diff = np.max(np.abs(t - target_t))
+        self.assertGreater(0.01, max_diff)
 
     def test_rng(self):
         t_max = 100
@@ -95,7 +114,7 @@ class TestModel(TestCase):
         # have changed from one snapshot to the next
         model = CNVM(self.params_network)
         t_max = 100
-        t, x = model.simulate(t_max)
+        _, x = model.simulate(t_max)
 
         for i in range(x.shape[0] - 1):
             self.assertFalse(np.allclose(x[i], x[i + 1]))
@@ -114,7 +133,7 @@ class TestModel(TestCase):
             )
             model = CNVM(params)
             t_max = 5
-            t, x = model.simulate(t_max)
+            _, x = model.simulate(t_max)
             self.assertEqual(correct_dtype, x.dtype)
 
             # network
@@ -126,7 +145,7 @@ class TestModel(TestCase):
             )
             model = CNVM(params)
             t_max = 5
-            t, x = model.simulate(t_max)
+            _, x = model.simulate(t_max)
             self.assertEqual(correct_dtype, x.dtype)
 
     def test_output_fill(self):


### PR DESCRIPTION
- Different optimized loops for when `len_output` is given or not.
- If `len_output` is given, now actually chooses the closest snapshots to the desired saving times. (See #18.)
- Simplification in `sample_many_runs`: no need for `argmatch` with the improved simulation loops.