### PR TITLE
Rework sample_many_runs

### DIFF
--- a/benchmarks/benchmark_mp.py
+++ b/benchmarks/benchmark_mp.py
@@ -1,0 +1,40 @@
+import time
+
+import sponet.network_generator as ng
+from sponet import CNVMParameters
+from sponet.collective_variables import OpinionShares
+from sponet.multiprocessing import sample_many_runs
+from sponet.states import sample_states_uniform
+
+
+def main():
+    num_opinions = 2
+    num_agents = 10000
+    network = ng.BarabasiAlbertGenerator(num_agents, m=3)()
+    params = CNVMParameters(
+        num_opinions=num_opinions, network=network, r=1, r_tilde=0.01
+    )
+    t_max = 1000
+    len_output = 1001
+    x_init = sample_states_uniform(num_agents, num_opinions, 1)
+    num_runs = 200
+    n_jobs = 4
+    cv = OpinionShares(num_opinions, normalize=True)
+
+    start = time.time()
+    sample_many_runs(
+        params,
+        x_init,
+        t_max,
+        len_output,
+        num_runs,
+        n_jobs=n_jobs,
+        collective_variable=cv,
+        progress_bar=True,
+    )
+    end = time.time()
+    print(f"Took {end - start} s")
+
+
+if __name__ == "__main__":
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -479,12 +479,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["notebooks", "test"]
+groups = ["main", "notebooks", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {notebooks = "sys_platform == \"win32\"", test = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "platform_system == \"Windows\"", notebooks = "sys_platform == \"win32\"", test = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "comm"
@@ -3173,6 +3173,28 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 description = "Traitlets Python configuration system"
@@ -3314,4 +3336,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "90b7581a2673826aa089a2f7cf2349697b7a2b5dd6be038b60e5285cef2bc204"
+content-hash = "d77f0cc2d3aab54eeb23b750c37a7bd699133588756e2c69016d6826ddfedb7d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "networkx>=2.8.4",
   "scipy>=1.9.3",
   "matplotlib>=3.6.0",
+  "tqdm (>=4.67.1,<5.0.0)",
 ]
 
 [tool.poetry.group.test]

--- a/sponet/multiprocessing.py
+++ b/sponet/multiprocessing.py
@@ -74,7 +74,7 @@ def sample_many_runs(
 
     # multiprocessing
     if n_jobs == -1:  # determine number of CPUs
-        n_jobs = os.process_cpu_count()
+        n_jobs = os.cpu_count()
         if n_jobs is None:
             raise RuntimeError("Could not determine number of available CPUs.")
 

--- a/sponet/multiprocessing.py
+++ b/sponet/multiprocessing.py
@@ -1,4 +1,4 @@
-import multiprocessing as mp
+import os
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
@@ -73,8 +73,10 @@ def sample_many_runs(
         return t_out, x_out
 
     # multiprocessing
-    if n_jobs == -1:
-        n_jobs = mp.cpu_count()
+    if n_jobs == -1:  # determine number of CPUs
+        n_jobs = os.process_cpu_count()
+        if n_jobs is None:
+            raise RuntimeError("Could not determine number of available CPUs.")
 
     rngs = rng.spawn(n_jobs)
 

--- a/sponet/sample_moments.py
+++ b/sponet/sample_moments.py
@@ -4,6 +4,7 @@ import time
 from typing import Optional
 
 import numpy as np
+from numpy.random import Generator, default_rng
 
 from sponet.multiprocessing import sample_many_runs
 
@@ -20,7 +21,7 @@ def sample_moments(
     rel_tol: float = 0.01,
     n_jobs: Optional[int] = None,
     collective_variable: Optional[CollectiveVariable] = None,
-    seed: Optional[int] = None,
+    rng: Generator = default_rng(),
     filename: Optional[str] = None,
     timeout_seconds: Optional[int] = None,
     verbose: bool = False,
@@ -52,9 +53,8 @@ def sample_moments(
     collective_variable : CollectiveVariable, optional
         If collective variable is specified, the projected trajectory will be returned
         instead of the full trajectory.
-    seed : int, optional
-        Seed for random number generation.
-        If multiprocessing is used, the subprocesses receive the seeds {seed, seed + 1, ...}.
+    rng : Generator, optional
+        Random number generator.
     filename : str, optional
         Save the results afer each batch using numpy.savez.
         The entries are "t", "mean", "variance", "num_samples", "confidence_size", "rel_error", "time_elapsed".
@@ -75,9 +75,6 @@ def sample_moments(
         if collective_variable is None
         else collective_variable.dimension
     )
-
-    if seed is None:
-        seed = np.random.default_rng().integers(2**31)
 
     if n_jobs is None:
         n_jobs = 1
@@ -103,9 +100,8 @@ def sample_moments(
             batch_size,
             n_jobs=n_jobs,
             collective_variable=collective_variable,
-            seed=seed,
+            rng=rng,
         )
-        seed += n_jobs  # each process should get a new seed
         num_samples += batch_size
         sum_x += np.sum(x[0], axis=0)
         sum_xx += np.sum(x[0] ** 2, axis=0)

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,9 +1,11 @@
 from unittest import TestCase
-import numpy as np
 
+import numpy as np
+from numpy.random import default_rng
+
+import sponet.multiprocessing as smp
 from sponet import CNVMParameters, sample_many_runs
 from sponet.collective_variables import OpinionShares
-import sponet.multiprocessing as smp
 
 
 class TestSampleManyRuns(TestCase):
@@ -127,7 +129,7 @@ class TestSampleManyRuns(TestCase):
                 r_tilde=1,
             )
 
-            t, x = sample_many_runs(
+            _, x = sample_many_runs(
                 params=params,
                 initial_states=self.initial_states,
                 t_max=5,
@@ -138,3 +140,29 @@ class TestSampleManyRuns(TestCase):
             )
 
             self.assertEqual(correct_dtype, x.dtype)
+
+    def test_reproducible(self):
+        rng = default_rng(123)
+        t1, x1 = sample_many_runs(
+            params=self.params,
+            initial_states=self.initial_states,
+            t_max=self.t_max,
+            num_timesteps=self.num_timesteps,
+            num_runs=15,
+            n_jobs=2,
+            rng=rng,
+        )
+
+        rng = default_rng(123)
+        t2, x2 = sample_many_runs(
+            params=self.params,
+            initial_states=self.initial_states,
+            t_max=self.t_max,
+            num_timesteps=self.num_timesteps,
+            num_runs=15,
+            n_jobs=2,
+            rng=rng,
+        )
+
+        self.assertTrue((t1 == t2).all())
+        self.assertTrue((x1 == x2).all())


### PR DESCRIPTION
- Usage of `np.random.Generator` instead of an integer seed.
- Replaced custom printing of progress with `tqdm` progressbar.
- Internally: Switch to `concurrent.futures.ProcessPoolExecutor` and use a `Worker` class, which makes the code a bit easier.